### PR TITLE
Allow ES6 source to be consumed directly by JSPM

### DIFF
--- a/lib/hyperagent.js
+++ b/lib/hyperagent.js
@@ -1,7 +1,7 @@
-import { Resource, LazyResource, LinkResource } from 'hyperagent/resource';
-import { Properties } from 'hyperagent/properties';
-import { CurieStore } from 'hyperagent/curie';
-import { config as _config } from 'hyperagent/config';
+import { Resource, LazyResource, LinkResource } from './hyperagent/resource';
+import { Properties } from './hyperagent/properties';
+import { CurieStore } from './hyperagent/curie';
+import { config as _config } from './hyperagent/config';
 
 function configure(name, value) {
   _config[name] = value;

--- a/lib/hyperagent/config.js
+++ b/lib/hyperagent/config.js
@@ -1,4 +1,4 @@
-import { _ } from 'hyperagent/miniscore';
+import { _ } from './miniscore';
 
 var config = {};
 

--- a/lib/hyperagent/curie.js
+++ b/lib/hyperagent/curie.js
@@ -1,3 +1,5 @@
+import URITemplate from 'urijs/src/URITemplate';
+
 /**
  * A simple data storage to register and expand CURIES:
  * http://www.w3.org/TR/curie/

--- a/lib/hyperagent/loader.js
+++ b/lib/hyperagent/loader.js
@@ -1,4 +1,4 @@
-import { config } from 'hyperagent/config';
+import { config } from './config';
 
 export function loadAjax(options) {
   var deferred = config.defer();

--- a/lib/hyperagent/properties.js
+++ b/lib/hyperagent/properties.js
@@ -1,4 +1,4 @@
-import { config } from 'hyperagent/config';
+import { config } from './config';
 
 export function Properties(response, options) {
   // XXX: This function is too large. Let's figure out if we could instead build

--- a/lib/hyperagent/resource.js
+++ b/lib/hyperagent/resource.js
@@ -1,8 +1,11 @@
 /*jshint strict:false, latedef:false */
-import { config } from 'hyperagent/config';
-import { loadAjax } from 'hyperagent/loader';
-import { Properties } from 'hyperagent/properties';
-import { CurieStore } from 'hyperagent/curie';
+import { config } from './config';
+import { loadAjax } from './loader';
+import { Properties } from './properties';
+import { CurieStore } from './curie';
+
+import URI from 'urijs';
+import URITemplate from 'urijs/src/URITemplate';
 
 var _ = config._;
 

--- a/package.json
+++ b/package.json
@@ -26,5 +26,13 @@
   },
   "scripts": {
     "test": "grunt test-ci"
+  },
+  "jspm": {
+    "directories": {
+      "lib": "lib"
+    },
+    "dependencies": {
+      "urijs": "npm:urijs@1.16.1"
+    }
   }
 }


### PR DESCRIPTION
- Make imports relative
- Add jspm config that points to 'lib' dir
